### PR TITLE
Use Ackermann steering angle instead of kappa in DRIVABLE trajectory

### DIFF
--- a/tf2_trajectory_planning_msgs/package.xml
+++ b/tf2_trajectory_planning_msgs/package.xml
@@ -24,6 +24,10 @@
   <buildtool_depend condition="$ROS_VERSION == 2">ament_cmake</buildtool_depend>
   <depend condition="$ROS_VERSION == 2">rclcpp</depend>
 
+  <test_depend condition="$ROS_VERSION == 2">ament_lint_auto</test_depend>
+  <test_depend condition="$ROS_VERSION == 2">ament_lint_common</test_depend>
+  <test_depend condition="$ROS_VERSION == 2">ament_cmake_gtest</test_depend>
+
   <!-- ROS1 -->
   <buildtool_depend condition="$ROS_VERSION == 1">catkin</buildtool_depend>
   <depend condition="$ROS_VERSION == 1">roscpp</depend>

--- a/tf2_trajectory_planning_msgs/test/impl/test_tf2_trajectory_planning_msgs.cpp
+++ b/tf2_trajectory_planning_msgs/test/impl/test_tf2_trajectory_planning_msgs.cpp
@@ -78,8 +78,7 @@ TEST(tf2_trajectory_planning_msgs, test_doTransform_DRIVABLE) {
     setV(trajectory, 1.0, i);
     setTheta(trajectory, M_PI, i);
     setA(trajectory, 1.0, i);
-    setKappa(trajectory, 1.0, i);
-    setDKappa(trajectory, 1.0, i);
+    setDeltaAck(trajectory, 1.0, i);
     setS(trajectory, 1.0, i);
   }
 
@@ -104,8 +103,7 @@ TEST(tf2_trajectory_planning_msgs, test_doTransform_DRIVABLE) {
     // transform-invariant state
     EXPECT_NEAR(getV(trajectory_tf, i), 1.0, EPS);
     EXPECT_NEAR(getA(trajectory_tf, i), 1.0, EPS);
-    EXPECT_NEAR(getKappa(trajectory_tf, i), 1.0, EPS);
-    EXPECT_NEAR(getDKappa(trajectory_tf, i), 1.0, EPS);
+    EXPECT_NEAR(getDeltaAck(trajectory_tf, i), 1.0, EPS);
     EXPECT_NEAR(getS(trajectory_tf, i), 1.0, EPS);
   }
 }

--- a/trajectory_planning_msgs/msg/DRIVABLE.msg
+++ b/trajectory_planning_msgs/msg/DRIVABLE.msg
@@ -1,5 +1,5 @@
 ###########################################################################################################################################################
-#   DRIVABLE Trajectory for bicycle model (ackermann steering)
+#   DRIVABLE Trajectory for bicycle model (Ackermann steering)
 ###########################################################################################################################################################
 uint8 TYPE_ID=1
 uint8 STATE_DIM=9
@@ -9,10 +9,9 @@ uint8 STATE_DIM=9
 uint8 T=0                           # time to reach sample point [s]
 uint8 X=1                           # x position of sample point in trajectory header frame [m]
 uint8 Y=2                           # y position of sample point in trajectory header frame [m]
-uint8 V=3                           # longitudinal (="absolute", according to ackermann) velocity in vehicle frame [m/s]
+uint8 V=3                           # longitudinal (="absolute", according to Ackermann) velocity in vehicle frame [m/s]
 uint8 THETA=4                       # heading at sample point in trajectory header frame [rad] from [-pi, pi]
-uint8 A=5                           # longitudinal (="absolute", according to ackermann) acceleration in vehicle frame [m/s^2]
-uint8 KAPPA=6                       # curvature of trajectory at sample point in [1/m]
-uint8 DKAPPA=7                      # curvature derivative of trajectory at sample point in [1/(m*s)]
-uint8 S=8                           # driven distance until sample point is reached in [m]
+uint8 A=5                           # longitudinal (="absolute", according to Ackermann) acceleration in vehicle frame [m/s^2]
+uint8 DELTA=6                       # Ackermann steering angle [rad] from [-pi, pi]
+uint8 S=7                           # driven distance until sample point is reached in [m]
 ###########################################################################################################################################################

--- a/trajectory_planning_msgs_utils/include/trajectory_planning_msgs_utils/impl/state_getters.h
+++ b/trajectory_planning_msgs_utils/include/trajectory_planning_msgs_utils/impl/state_getters.h
@@ -242,36 +242,22 @@ inline double getDeltaRear(const Trajectory& trajectory, const unsigned int i) {
   return getDeltaRear(trajectory.states, trajectory.type_id, i);
 }
 
-inline double getKappa(const std::vector<double>& state, const unsigned char& type_id) {
+inline double getDeltaAck(const std::vector<double>& state, const unsigned char& type_id) {
   sanityCheckStateSize(state, type_id);
-  return state[indexKappa(type_id)];
+  double delta_ack = state[indexDeltaAck(type_id)];
+  sanityCheckAngle(delta_ack);
+  return delta_ack;
 }
 
-inline double getKappa(const std::vector<double>& states, const unsigned char& type_id, const unsigned int i) {
+inline double getDeltaAck(const std::vector<double>& states, const unsigned char& type_id, const unsigned int i) {
   sanityCheckStatesSize(states, type_id);
   std::vector<double> state = getState(states, type_id, i);
-  return getKappa(state, type_id);
+  return getDeltaAck(state, type_id);
 }
 
-inline double getKappa(const Trajectory& trajectory, const unsigned int i) {
+inline double getDeltaAck(const Trajectory& trajectory, const unsigned int i) {
   sanityCheckTrajectory(trajectory);
-  return getKappa(trajectory.states, trajectory.type_id, i);
-}
-
-inline double getDKappa(const std::vector<double>& state, const unsigned char& type_id) {
-  sanityCheckStateSize(state, type_id);
-  return state[indexDKappa(type_id)];
-}
-
-inline double getDKappa(const std::vector<double>& states, const unsigned char& type_id, const unsigned int i) {
-  sanityCheckStatesSize(states, type_id);
-  std::vector<double> state = getState(states, type_id, i);
-  return getDKappa(state, type_id);
-}
-
-inline double getDKappa(const Trajectory& trajectory, const unsigned int i) {
-  sanityCheckTrajectory(trajectory);
-  return getDKappa(trajectory.states, trajectory.type_id, i);
+  return getDeltaAck(trajectory.states, trajectory.type_id, i);
 }
 
 inline double getS(const std::vector<double>& state, const unsigned char& type_id) {

--- a/trajectory_planning_msgs_utils/include/trajectory_planning_msgs_utils/impl/state_index.h
+++ b/trajectory_planning_msgs_utils/include/trajectory_planning_msgs_utils/impl/state_index.h
@@ -132,21 +132,12 @@ inline int indexDeltaRear(const unsigned char& type_id) {
   }
 }
 
-inline int indexKappa(const unsigned char& type_id) {
+inline int indexDeltaAck(const unsigned char& type_id) {
   switch (type_id) {
     case DRIVABLE::TYPE_ID:
-      return DRIVABLE::KAPPA;
+      return DRIVABLE::DELTA;
     default:
-      throw std::invalid_argument(kExceptionUnknownStateEntry + std::to_string(type_id) + ", " + "kappa");
-  }
-}
-
-inline int indexDKappa(const unsigned char& type_id) {
-  switch (type_id) {
-    case DRIVABLE::TYPE_ID:
-      return DRIVABLE::DKAPPA;
-    default:
-      throw std::invalid_argument(kExceptionUnknownStateEntry + std::to_string(type_id) + ", " + "dKappa");
+      throw std::invalid_argument(kExceptionUnknownStateEntry + std::to_string(type_id) + ", " + "delta");
   }
 }
 
@@ -278,20 +269,7 @@ inline bool hasDeltaRear(const unsigned char& type_id) {
   }
 }
 
-inline bool hasKappa(const unsigned char& type_id) {
-  switch (type_id) {
-    case DRIVABLE::TYPE_ID:
-      return true;
-    case DRIVABLERWS::TYPE_ID:
-      return false;
-    case REFERENCE::TYPE_ID:
-      return false;
-    default:
-      return false;
-  }
-}
-
-inline bool hasDKappa(const unsigned char& type_id) {
+inline bool hasDeltaAck(const unsigned char& type_id) {
   switch (type_id) {
     case DRIVABLE::TYPE_ID:
       return true;

--- a/trajectory_planning_msgs_utils/include/trajectory_planning_msgs_utils/impl/state_setters.h
+++ b/trajectory_planning_msgs_utils/include/trajectory_planning_msgs_utils/impl/state_setters.h
@@ -289,42 +289,29 @@ inline void setDeltaRear(Trajectory& trajectory, const double val, const unsigne
   setDeltaRear(trajectory.states, trajectory.type_id, val, i);
 }
 
-inline void setKappa(std::vector<double>& state, const unsigned char& type_id, const double val) {
+inline void setDeltaAck(std::vector<double>& state, const unsigned char& type_id, const double val) {
   sanityCheckStateSize(state, type_id);
-  const int idx = indexKappa(type_id);
-  state[idx] = val;
+  const int idx = indexDeltaAck(type_id);
+  try {
+    sanityCheckAngle(val);
+    state[idx] = val;
+  } catch (const std::invalid_argument& e) {
+    std::cout << "Invalid angle value: " << val << ", wrapping to [-π, π]" << std::endl;
+    state[idx] = wrapAngle(val);
+  }
 }
 
-inline void setKappa(std::vector<double>& states, const unsigned char& type_id, const double val,
+inline void setDeltaAck(std::vector<double>& states, const unsigned char& type_id, const double val,
                      const unsigned int i) {
   sanityCheckStatesSize(states, type_id);
   std::vector<double> state = getState(states, type_id, i);
-  setKappa(state, type_id, val);
+  setDeltaAck(state, type_id, val);
   setState(states, type_id, state, i);
 }
 
-inline void setKappa(Trajectory& trajectory, const double val, const unsigned int i) {
+inline void setDeltaAck(Trajectory& trajectory, const double val, const unsigned int i) {
   sanityCheckTrajectory(trajectory);
-  setKappa(trajectory.states, trajectory.type_id, val, i);
-}
-
-inline void setDKappa(std::vector<double>& state, const unsigned char& type_id, const double val) {
-  sanityCheckStateSize(state, type_id);
-  const int idx = indexDKappa(type_id);
-  state[idx] = val;
-}
-
-inline void setDKappa(std::vector<double>& states, const unsigned char& type_id, const double val,
-                      const unsigned int i) {
-  sanityCheckStatesSize(states, type_id);
-  std::vector<double> state = getState(states, type_id, i);
-  setDKappa(state, type_id, val);
-  setState(states, type_id, state, i);
-}
-
-inline void setDKappa(Trajectory& trajectory, const double val, const unsigned int i) {
-  sanityCheckTrajectory(trajectory);
-  setDKappa(trajectory.states, trajectory.type_id, val, i);
+  setDeltaAck(trajectory.states, trajectory.type_id, val, i);
 }
 
 inline void setS(std::vector<double>& state, const unsigned char& type_id, const double val) {

--- a/trajectory_planning_msgs_utils/package.xml
+++ b/trajectory_planning_msgs_utils/package.xml
@@ -18,6 +18,7 @@
 
   <test_depend condition="$ROS_VERSION == 2">ament_lint_auto</test_depend>
   <test_depend condition="$ROS_VERSION == 2">ament_lint_common</test_depend>
+  <test_depend condition="$ROS_VERSION == 2">ament_cmake_gtest</test_depend>
 
   <!-- ROS1 -->
   <buildtool_depend condition="$ROS_VERSION == 1">catkin</buildtool_depend>

--- a/trajectory_planning_msgs_utils/test/impl/test_trajectory_access.cpp
+++ b/trajectory_planning_msgs_utils/test/impl/test_trajectory_access.cpp
@@ -119,15 +119,10 @@ TEST(trajectory_planning_msgs, test_set_get_DRIVABLE) {
     setA(tra, val, i);
     EXPECT_DOUBLE_EQ(val, getA(tra, i));
 
-    // set/getKappa
+    // set/getDeltaAck
     val = randomValue();
-    setKappa(tra, val, i);
-    EXPECT_DOUBLE_EQ(val, getKappa(tra, i));
-
-    // set/getDKappa
-    val = randomValue();
-    setDKappa(tra, val, i);
-    EXPECT_DOUBLE_EQ(val, getDKappa(tra, i));
+    setDeltaAck(tra, val, i);
+    EXPECT_DOUBLE_EQ(val, getDeltaAck(tra, i));
 
     // set/getS
     val = randomValue();


### PR DESCRIPTION
- removed `kappa` and `dKappa` from DRIVABLE trajectory
- instead added the Ackermann steering angle `delta`
- this makes the ("Ackermann") model more explicit