### PR TITLE
Fix visibility of regulatory elements timing information

### DIFF
--- a/route_planning_msgs_rviz_plugins/src/displays/route/route_display.cpp
+++ b/route_planning_msgs_rviz_plugins/src/displays/route/route_display.cpp
@@ -93,11 +93,11 @@ void RouteDisplay::onInitialize() {
   viz_suggested_lane_regulatory_elements_sign_positions_ = std::make_unique<rviz_common::properties::BoolProperty>(
       "Positions", true, "Whether to display the sign positions of the regulatory elements of the suggested lane.", viz_suggested_lane_regulatory_elements_.get());
   viz_suggested_lane_regulatory_elements_timing_information_ = std::make_unique<rviz_common::properties::BoolProperty>(
-      "Timing Information", true, "Whether to display the timing information of the regulatory elements of the suggested lane.", viz_suggested_lane_regulatory_elements_.get());
+      "Validity stamp", false, "Whether to display the validity stamp of the regulatory elements of the suggested lane.", viz_suggested_lane_regulatory_elements_.get());
   color_property_suggested_lane_regulatory_elements_timing_information_ = std::make_unique<rviz_common::properties::ColorProperty>(
-      "Color", QColor(255, 255, 255), "Color to draw timing information of the regulatory elements of the suggested lane.", viz_suggested_lane_regulatory_elements_timing_information_.get());
+      "Color", QColor(255, 255, 255), "Color to draw validity stamp of the regulatory elements of the suggested lane.", viz_suggested_lane_regulatory_elements_timing_information_.get());
   scale_property_suggested_lane_regulatory_elements_timing_information_ = std::make_unique<rviz_common::properties::FloatProperty>(
-      "Scale", 4.0, "Scale of the timing information of the regulatory elements of the suggested lane.", viz_suggested_lane_regulatory_elements_timing_information_.get());
+      "Scale", 0.6, "Scale of the validity stamp of the regulatory elements of the suggested lane.", viz_suggested_lane_regulatory_elements_timing_information_.get());
 
   // lane change
   viz_lane_change_ = std::make_unique<rviz_common::properties::BoolProperty>(
@@ -152,11 +152,11 @@ void RouteDisplay::onInitialize() {
   viz_adjacent_lane_regulatory_elements_sign_positions_ = std::make_unique<rviz_common::properties::BoolProperty>(
       "Positions", true, "Whether to display the sign positions of the regulatory elements of adjacent lanes.", viz_adjacent_lane_regulatory_elements_.get());
   viz_adjacent_lane_regulatory_elements_timing_information_ = std::make_unique<rviz_common::properties::BoolProperty>(
-      "Timing Information", true, "Whether to display the timing information of the regulatory elements of adjacent lanes.", viz_adjacent_lane_regulatory_elements_.get());
+      "Validity stamp", false, "Whether to display the validity stamp of the regulatory elements of adjacent lanes.", viz_adjacent_lane_regulatory_elements_.get());
   color_property_adjacent_lane_regulatory_elements_timing_information_ = std::make_unique<rviz_common::properties::ColorProperty>(
-      "Color", QColor(255, 255, 255), "Color to draw timing information of the regulatory elements of adjacent lanes.", viz_adjacent_lane_regulatory_elements_timing_information_.get());
+      "Color", QColor(255, 255, 255), "Color to draw validity stamp of the regulatory elements of adjacent lanes.", viz_adjacent_lane_regulatory_elements_timing_information_.get());
   scale_property_adjacent_lane_regulatory_elements_timing_information_ = std::make_unique<rviz_common::properties::FloatProperty>(
-      "Scale", 4.0, "Scale of the timing information of the regulatory elements of adjacent lanes.", viz_adjacent_lane_regulatory_elements_timing_information_.get());
+      "Scale", 0.6, "Scale of the validity stamp of the regulatory elements of adjacent lanes.", viz_adjacent_lane_regulatory_elements_timing_information_.get());
 
   // drivable space
   viz_drivable_space_ = std::make_unique<rviz_common::properties::BoolProperty>(
@@ -397,10 +397,12 @@ void RouteDisplay::processMessage(const route_planning_msgs::msg::Route::ConstSh
           for (const auto& position : regulatory_element.positions) {
             suggested_lane_regulatory_elements_sign_positions_.push_back(generateRenderPoint(position, color_reg_elem, 0.5));
             if (show_suggested_lane_regulatory_elements_timing_information) {
-              std::string text = "No validity stamp";
+              std::string text = "no stamp";
               if (regulatory_element.has_validity_stamp) {
                 double validity_stamp = rclcpp::Time(regulatory_element.validity_stamp).seconds();
-                text = "Valid until: " + std::to_string(validity_stamp);
+                std::stringstream ss;
+                ss << std::fixed << std::setprecision(2) << validity_stamp;
+                text = ss.str();
               }
               auto timing_text = std::make_shared<rviz_rendering::MovableText>(text, "Liberation Sans", scale_suggested_lane_regulatory_elements_timing_information, color_suggested_lane_regulatory_elements_timing_information);
               Ogre::Vector3 text_position(position.x, position.y, position.z + 0.5);
@@ -485,10 +487,12 @@ void RouteDisplay::processMessage(const route_planning_msgs::msg::Route::ConstSh
               for (const auto& position : regulatory_element.positions) {
                 adjacent_lane_regulatory_elements_sign_positions_.push_back(generateRenderPoint(position, color_reg_elem, 0.5));
                 if (show_adjacent_lane_regulatory_elements_timing_information) {
-                  std::string text = "No validity stamp";
+                  std::string text = "no stamp";
                   if (regulatory_element.has_validity_stamp) {
                     double validity_stamp = rclcpp::Time(regulatory_element.validity_stamp).seconds();
-                    text = "Valid until: " + std::to_string(validity_stamp);
+                    std::stringstream ss;
+                    ss << std::fixed << std::setprecision(2) << validity_stamp;
+                    text = ss.str();
                   }
                   auto timing_text = std::make_shared<rviz_rendering::MovableText>(text, "Liberation Sans", scale_adjacent_lane_regulatory_elements_timing_information, color_adjacent_lane_regulatory_elements_timing_information);
                   Ogre::Vector3 text_position(position.x, position.y, position.z + 0.5);


### PR DESCRIPTION
<img width="779" height="477" alt="image" src="https://github.com/user-attachments/assets/77a3be72-a02a-420f-9907-306f75c9dacf" />

Timing information is now visible