### PR TITLE
Add intermediate goals to plan route action | Add RViz tool for route planning | Add RViz plugin icons

### DIFF
--- a/route_planning_msgs/action/PlanRoute.action
+++ b/route_planning_msgs/action/PlanRoute.action
@@ -1,14 +1,14 @@
 # goal
-geometry_msgs/PointStamped destination      # route destination
-geometry_msgs/PointStamped[] intermediates  # route should be planned over those points (could be empty) 
+geometry_msgs/PointStamped destination                  # route destination
+geometry_msgs/PointStamped[] intermediate_destinations  # route should be planned over those points (could be empty) 
 ---
 # result
-bool destination_reached                    # if destination was reached
-float64 distance_traveled                   # distance traveled since start
-builtin_interfaces/Duration time_traveled   # time traveled since start
+bool destination_reached                                # if destination was reached
+float64 distance_traveled                               # distance traveled since start
+builtin_interfaces/Duration time_traveled               # time traveled since start
 ---
 # feedback
-float64 distance_remaining                  # distance remaining to destination
-float64 distance_traveled                   # distance traveled since start
-builtin_interfaces/Duration time_remaining  # remaining time to destination
-builtin_interfaces/Duration time_traveled   # time traveled since start
+float64 distance_remaining                              # distance remaining to destination
+float64 distance_traveled                               # distance traveled since start
+builtin_interfaces/Duration time_remaining              # remaining time to destination
+builtin_interfaces/Duration time_traveled               # time traveled since start

--- a/route_planning_msgs/action/PlanRoute.action
+++ b/route_planning_msgs/action/PlanRoute.action
@@ -1,5 +1,6 @@
 # goal
 geometry_msgs/PointStamped destination      # route destination
+geometry_msgs/PointStamped[] intermediates  # route should be planned over those points (could be empty) 
 ---
 # result
 bool destination_reached                    # if destination was reached

--- a/route_planning_msgs/msg/Route.msg
+++ b/route_planning_msgs/msg/Route.msg
@@ -1,10 +1,10 @@
 std_msgs/Header header
 
-geometry_msgs/Point destination         # destination (potentially mapped to suggested lane reference line)
-geometry_msgs/Point[] intermediates     # route should be planned over those points (could be empty) 
+geometry_msgs/Point destination                 # destination (potentially mapped to suggested lane reference line)
+geometry_msgs/Point[] intermediate_destinations # route should be planned over those points (could be empty) 
 
-RouteElement[] route_elements           # cross sections of drivable adjacent lanes in driving direction towards destination
+RouteElement[] route_elements                   # cross sections of drivable adjacent lanes in driving direction towards destination
 
-uint64 starting_route_element_idx       # index of the route element right before the starting point
-uint64 current_route_element_idx        # index of the first route element of the remaining route, right before the current position
-uint64 destination_route_element_idx    # index of the route element right behind the destination
+uint64 starting_route_element_idx               # index of the route element right before the starting point
+uint64 current_route_element_idx                # index of the first route element of the remaining route, right before the current position
+uint64 destination_route_element_idx            # index of the route element right behind the destination

--- a/route_planning_msgs/msg/Route.msg
+++ b/route_planning_msgs/msg/Route.msg
@@ -1,6 +1,7 @@
 std_msgs/Header header
 
 geometry_msgs/Point destination         # destination (potentially mapped to suggested lane reference line)
+geometry_msgs/Point[] intermediates     # route should be planned over those points (could be empty) 
 
 RouteElement[] route_elements           # cross sections of drivable adjacent lanes in driving direction towards destination
 

--- a/route_planning_msgs_rviz_plugins/CMakeLists.txt
+++ b/route_planning_msgs_rviz_plugins/CMakeLists.txt
@@ -36,6 +36,7 @@ if(${ROS_VERSION} EQUAL 2)
 
   set(tool_headers_to_moc
     include/route_planning_msgs/tools/route/ref_path_tool.hpp
+    include/route_planning_msgs/tools/route/plan_route_tool.hpp
   )
 
   foreach(header "${display_headers_to_moc}")
@@ -52,6 +53,7 @@ if(${ROS_VERSION} EQUAL 2)
 
   set(tool_source_files
     src/tools/route/ref_path_tool.cpp
+    src/tools/route/plan_route_tool.cpp
   )
 
   add_library(${PROJECT_NAME} SHARED

--- a/route_planning_msgs_rviz_plugins/CMakeLists.txt
+++ b/route_planning_msgs_rviz_plugins/CMakeLists.txt
@@ -115,6 +115,11 @@ if(${ROS_VERSION} EQUAL 2)
     LIBRARY DESTINATION lib
     RUNTIME DESTINATION bin
   )
+
+  install(
+    DIRECTORY icons/classes/
+    DESTINATION share/${PROJECT_NAME}/icons/classes
+  )
   # RViz Display End
 
   if(BUILD_TESTING)

--- a/route_planning_msgs_rviz_plugins/icons/classes/PlanRoute.png
+++ b/route_planning_msgs_rviz_plugins/icons/classes/PlanRoute.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0189a41b98644d0064b7416670e5cd8f6149eeb5a31cbe65af118d20e76ad06a
+size 1149

--- a/route_planning_msgs_rviz_plugins/icons/classes/ReferencePath.png
+++ b/route_planning_msgs_rviz_plugins/icons/classes/ReferencePath.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e5bd59a4fb23aca77b1d39d4e9df838174f3b05a592d20612f89286bbde99802
+size 1045

--- a/route_planning_msgs_rviz_plugins/icons/classes/Route.png
+++ b/route_planning_msgs_rviz_plugins/icons/classes/Route.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f451428f169be6ab1b20cfb4c23d667bdd0a9e79162ed3fd1e589a24f9b45bf8
+size 476

--- a/route_planning_msgs_rviz_plugins/include/route_planning_msgs/displays/route/route_display.hpp
+++ b/route_planning_msgs_rviz_plugins/include/route_planning_msgs/displays/route/route_display.hpp
@@ -72,6 +72,8 @@ class RouteDisplay : public rviz_common::MessageFilterDisplay<route_planning_msg
   std::unique_ptr<rviz_common::properties::BoolProperty> viz_destination_;
   std::unique_ptr<rviz_common::properties::FloatProperty> scale_property_destination_;
   std::unique_ptr<rviz_common::properties::ColorProperty> color_property_destination_;
+  std::unique_ptr<rviz_common::properties::FloatProperty> scale_property_intermediate_destinations_;
+  std::unique_ptr<rviz_common::properties::ColorProperty> color_property_intermediate_destinations_;
 
   // traveled route
   std::unique_ptr<rviz_common::properties::BoolProperty> viz_traveled_route_;

--- a/route_planning_msgs_rviz_plugins/include/route_planning_msgs/displays/route/route_display.hpp
+++ b/route_planning_msgs_rviz_plugins/include/route_planning_msgs/displays/route/route_display.hpp
@@ -68,7 +68,7 @@ class RouteDisplay : public rviz_common::MessageFilterDisplay<route_planning_msg
   std::shared_ptr<rviz_rendering::BillboardLine> generateRenderLine(const std::vector<geometry_msgs::msg::Point>& points, const Ogre::ColourValue& color, const float scale, const float opacity = 1.0, const float vertical_offset = 0.0);
 
   // destination
-  std::shared_ptr<rviz_rendering::Arrow> destination_arrow_;
+  std::vector<std::shared_ptr<rviz_rendering::Arrow>> destination_arrows_;
   std::unique_ptr<rviz_common::properties::BoolProperty> viz_destination_;
   std::unique_ptr<rviz_common::properties::FloatProperty> scale_property_destination_;
   std::unique_ptr<rviz_common::properties::ColorProperty> color_property_destination_;

--- a/route_planning_msgs_rviz_plugins/include/route_planning_msgs/tools/route/plan_route_tool.hpp
+++ b/route_planning_msgs_rviz_plugins/include/route_planning_msgs/tools/route/plan_route_tool.hpp
@@ -69,7 +69,7 @@ class PlanRouteTool : public rviz_default_plugins::tools::PoseTool {
   void deactivate() override;
 
  protected:
-  void onPoseSet(double x, double y, double theta) override;
+  void onPoseSet(double x, double y, double theta) override; // needs to be overridden because of base class
   int processMouseEvent(rviz_common::ViewportMouseEvent& event) override;
 
  private Q_SLOTS:
@@ -91,7 +91,7 @@ class PlanRouteTool : public rviz_default_plugins::tools::PoseTool {
   rviz_common::properties::QosProfileProperty* qos_profile_property_;
 
   geometry_msgs::msg::PointStamped destination_;
-  std::vector<geometry_msgs::msg::PointStamped> intermediates_;
+  std::vector<geometry_msgs::msg::PointStamped> intermediate_destinations_;
   std::vector<std::shared_ptr<rviz_rendering::Shape>> intermediate_shapes_;
 
   std::unique_ptr<tf2_ros::Buffer> tf2_buffer_;

--- a/route_planning_msgs_rviz_plugins/include/route_planning_msgs/tools/route/plan_route_tool.hpp
+++ b/route_planning_msgs_rviz_plugins/include/route_planning_msgs/tools/route/plan_route_tool.hpp
@@ -78,7 +78,7 @@ class PlanRouteTool : public rviz_default_plugins::tools::PoseTool {
   int processMouseRightButtonPressed(std::pair<bool, Ogre::Vector3> xy_plane_intersection);
   int processMouseMiddleButtonPressed();
   void planRoute();
-  void drawIntermediates(std::vector<geometry_msgs::msg::Point> points);
+  void drawIntermediates(std::vector<geometry_msgs::msg::PointStamped>& points);
 
  private:
 

--- a/route_planning_msgs_rviz_plugins/include/route_planning_msgs/tools/route/plan_route_tool.hpp
+++ b/route_planning_msgs_rviz_plugins/include/route_planning_msgs/tools/route/plan_route_tool.hpp
@@ -1,0 +1,102 @@
+/** ============================================================================
+MIT License
+
+Copyright (c) 2025 Institute for Automotive Engineering (ika), RWTH Aachen University
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+============================================================================= */
+
+#include <QObject>
+#include <string>
+#include <vector>
+
+#include <tf2_ros/buffer.h>
+#include <tf2_ros/transform_listener.h>
+#include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
+
+#include "geometry_msgs/msg/pose_array.hpp"
+#include "geometry_msgs/msg/pose_stamped.hpp"
+#include "rclcpp/node.hpp"
+#include "rclcpp/qos.hpp"
+
+#include "rviz_default_plugins/tools/pose/pose_tool.hpp"
+#include "rviz_default_plugins/visibility_control.hpp"
+#include "rviz_rendering/objects/shape.hpp"
+
+#include <rclcpp_action/rclcpp_action.hpp>
+#include <route_planning_msgs/action/plan_route.hpp>
+
+namespace rviz_common {
+class DisplayContext;
+namespace properties {
+class StringProperty;
+class QosProfileProperty;
+class BoolProperty;
+class FloatProperty;
+class VectorProperty;
+}  // namespace properties
+}  // namespace rviz_common
+
+namespace route_planning_msgs {
+namespace tools {
+class PlanRouteTool : public rviz_default_plugins::tools::PoseTool {
+  Q_OBJECT
+
+ public:
+  PlanRouteTool();
+
+  ~PlanRouteTool() override;
+
+  void onInitialize() override;
+
+  void activate() override;
+  void deactivate() override;
+
+ protected:
+  void onPoseSet(double x, double y, double theta) override;
+  int processMouseEvent(rviz_common::ViewportMouseEvent& event) override;
+
+ private Q_SLOTS:
+  void updateActionServer();
+  int processMouseLeftButtonPressed(std::pair<bool, Ogre::Vector3> xy_plane_intersection);
+  int processMouseRightButtonPressed(std::pair<bool, Ogre::Vector3> xy_plane_intersection);
+  int processMouseMiddleButtonPressed();
+  void planRoute();
+  void drawIntermediates(std::vector<geometry_msgs::msg::Point> points);
+
+ private:
+
+  rclcpp_action::Client<route_planning_msgs::action::PlanRoute>::SharedPtr action_client_;
+
+  rclcpp::Clock::SharedPtr clock_;
+  rclcpp::QoS qos_profile_;
+
+  rviz_common::properties::StringProperty* action_server_property_;
+  rviz_common::properties::QosProfileProperty* qos_profile_property_;
+
+  geometry_msgs::msg::PointStamped destination_;
+  std::vector<geometry_msgs::msg::PointStamped> intermediates_;
+  std::vector<std::shared_ptr<rviz_rendering::Shape>> intermediate_shapes_;
+
+  std::unique_ptr<tf2_ros::Buffer> tf2_buffer_;
+  std::shared_ptr<tf2_ros::TransformListener> tf2_listener_;
+};
+
+}  // namespace tools
+}  // namespace route_planning_msgs

--- a/route_planning_msgs_rviz_plugins/include/route_planning_msgs/tools/route/ref_path_tool.hpp
+++ b/route_planning_msgs_rviz_plugins/include/route_planning_msgs/tools/route/ref_path_tool.hpp
@@ -77,8 +77,8 @@ class ReferencePathTool : public rviz_default_plugins::tools::PoseTool {
   void updateInitPoint();
   bool setInitPoint();
   void updateFrame();
-  int processMouseLeftButtonPressed(std::pair<bool, Ogre::Vector3> xy_plane_intersection);
-  int processMouseRightButtonPressed();
+  int processMouseLeftButtonPressed();
+  int processMouseRightButtonPressed(std::pair<bool, Ogre::Vector3> xy_plane_intersection);
   int processMouseMiddleButtonPressed();
   bool fillRoute(std::vector<geometry_msgs::msg::PointStamped> ref_path_points);
   void initRoute();

--- a/route_planning_msgs_rviz_plugins/plugins_description.xml
+++ b/route_planning_msgs_rviz_plugins/plugins_description.xml
@@ -20,6 +20,7 @@
   >
     <description>
       Publishes a reference path as route_planning_msgs::Route created in rviz.
+      Right click to add suggested lane points, middle click to remove the last suggested lane point and left click to publish the route.
     </description>
     <message_type>route_planning_msgs/msg/Route</message_type>
   </class>
@@ -30,6 +31,7 @@
   >
     <description>
       Plans a route based on the user input in rviz and calls the route_planning_msgs::action::PlanRoute action.
+      Right click to add intermediate destinations, middle click to remove the last intermediate destination and left click to set the destination and call the action.
     </description>
     <action_type>route_planning_msgs/action/PlanRoute</action_type>
   </class>

--- a/route_planning_msgs_rviz_plugins/plugins_description.xml
+++ b/route_planning_msgs_rviz_plugins/plugins_description.xml
@@ -23,5 +23,15 @@
     </description>
     <message_type>route_planning_msgs/msg/Route</message_type>
   </class>
+  <class
+    name="route_planning_msgs/PlanRoute"
+    type="route_planning_msgs::tools::PlanRouteTool"
+    base_class_type="rviz_common::Tool"
+  >
+    <description>
+      Plans a route based on the user input in rviz and calls the route_planning_msgs::action::PlanRoute action.
+    </description>
+    <action_type>route_planning_msgs/action/PlanRoute</action_type>
+  </class>
 
 </library>

--- a/route_planning_msgs_rviz_plugins/src/displays/route/route_display.cpp
+++ b/route_planning_msgs_rviz_plugins/src/displays/route/route_display.cpp
@@ -38,13 +38,13 @@ void RouteDisplay::onInitialize() {
   viz_destination_ = std::make_unique<rviz_common::properties::BoolProperty>(
       "Destination", true, "Whether to display the destination arrow.", this);
   color_property_destination_ = std::make_unique<rviz_common::properties::ColorProperty>(
-      "Color", QColor(255, 0, 255), "Color to draw the destination arrow.", viz_destination_.get());
+      "Color (final)", QColor(255, 0, 255), "Color to draw the destination arrow.", viz_destination_.get());
   scale_property_destination_ = std::make_unique<rviz_common::properties::FloatProperty>(
-      "Scale", 1.0, "Scale of the destination arrow.", viz_destination_.get());
+      "Scale (final)", 1.0, "Scale of the destination arrow.", viz_destination_.get());
   color_property_intermediate_destinations_ = std::make_unique<rviz_common::properties::ColorProperty>(
-      "Color", QColor(255, 0, 200), "Color to draw the intermediate destinations.", viz_destination_.get());
+      "Color (intermediate)", QColor(150, 0, 255), "Color to draw the intermediate destinations.", viz_destination_.get());
   scale_property_intermediate_destinations_ = std::make_unique<rviz_common::properties::FloatProperty>(
-      "Scale", 0.5, "Scale of the intermediate destinations.", viz_destination_.get());
+      "Scale (intermediate)", 1.0, "Scale of the intermediate destinations.", viz_destination_.get());
 
   // traveled route
   viz_traveled_route_ = std::make_unique<rviz_common::properties::BoolProperty>(
@@ -164,7 +164,7 @@ void RouteDisplay::onInitialize() {
 
   // drivable space
   viz_drivable_space_ = std::make_unique<rviz_common::properties::BoolProperty>(
-      "Drivable Space", true, "Whether to display the the drivable space.", this);
+      "Drivable Space", false, "Whether to display the the drivable space.", this);
 
   viz_drivable_space_points_ = std::make_unique<rviz_common::properties::BoolProperty>(
       "Points", false, "Whether to display the points of the drivable space.", viz_drivable_space_.get());

--- a/route_planning_msgs_rviz_plugins/src/tools/route/plan_route_tool.cpp
+++ b/route_planning_msgs_rviz_plugins/src/tools/route/plan_route_tool.cpp
@@ -1,0 +1,218 @@
+/** ============================================================================
+MIT License
+
+Copyright (c) 2025 Institute for Automotive Engineering (ika), RWTH Aachen University
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+============================================================================= */
+
+#include "route_planning_msgs/tools/route/plan_route_tool.hpp"
+
+#include <OgreSceneNode.h>
+
+#include "rviz_common/display_context.hpp"
+#include "rviz_common/logging.hpp"
+#include "rviz_common/properties/bool_property.hpp"
+#include "rviz_common/properties/float_property.hpp"
+#include "rviz_common/properties/qos_profile_property.hpp"
+#include "rviz_common/properties/string_property.hpp"
+#include "rviz_common/properties/vector_property.hpp"
+#include "rviz_common/render_panel.hpp"
+#include "rviz_common/viewport_mouse_event.hpp"
+#include "rviz_rendering/geometry.hpp"
+#include "rviz_rendering/objects/arrow.hpp"
+#include "rviz_rendering/objects/line.hpp"
+#include "rviz_rendering/render_window.hpp"
+
+namespace route_planning_msgs {
+namespace tools {
+
+PlanRouteTool::PlanRouteTool() : rviz_default_plugins::tools::PoseTool(), qos_profile_(5) {
+  shortcut_key_ = 'p';
+
+  action_server_property_ = new rviz_common::properties::StringProperty("Action server", "/lanelet2_route_planning/plan_route",
+                                                                        "The action server to call for planning a route.",
+                                                                        getPropertyContainer(), SLOT(updateActionServer()), this);
+
+  qos_profile_property_ = new rviz_common::properties::QosProfileProperty(action_server_property_, qos_profile_);
+}
+
+PlanRouteTool::~PlanRouteTool() = default;
+
+void PlanRouteTool::onInitialize() {
+  arrow_ = std::make_shared<rviz_rendering::Arrow>(scene_manager_, nullptr, 0.5f, 0.1f, 0.2f,
+                                                   0.35f);  // does not matter which shape, but it must be initialized
+  arrow_->getSceneNode()->setVisible(false);
+  qos_profile_property_->initialize([this](rclcpp::QoS profile) { this->qos_profile_ = profile; });
+  updateActionServer();
+  tf2_buffer_ = std::make_unique<tf2_ros::Buffer>(clock_, tf2::Duration(std::chrono::seconds(60)));
+  tf2_listener_ = std::make_shared<tf2_ros::TransformListener>(*tf2_buffer_);
+}
+
+void PlanRouteTool::activate() { PoseTool::activate(); }
+
+void PlanRouteTool::deactivate() { PoseTool::deactivate(); }
+
+void PlanRouteTool::updateActionServer() {
+  rclcpp::Node::SharedPtr raw_node = context_->getRosNodeAbstraction().lock()->get_raw_node();
+  action_client_ = raw_node->template create_client<route_planning_msgs::action::PlanRoute>(
+      action_server_property_->getStdString(), qos_profile_);
+  clock_ = raw_node->get_clock();
+}
+
+void PlanRouteTool::onPoseSet(double x, double y, double theta) {
+  (void)theta; // theta is not used in this tool, do not warn about unused variable
+  geometry_msgs::msg::PointStamped point;
+  point.header.stamp = clock_->now();
+  point.header.frame_id = context_->getFixedFrame().toStdString();
+  point.point.x = x;
+  point.point.y = y;
+  point.point.z = 0.0;
+
+  destination_ = point;
+}
+
+int PlanRouteTool::processMouseEvent(rviz_common::ViewportMouseEvent& event) {
+  auto point_projection_on_xy_plane =
+      projection_finder_->getViewportPointProjectionOnXYPlane(event.panel->getRenderWindow(), event.x, event.y);
+
+  if (event.leftDown()) {
+    return processMouseLeftButtonPressed(point_projection_on_xy_plane); // add destination and plan route
+  } else if (event.rightDown()) {
+    return processMouseRightButtonPressed(point_projection_on_xy_plane); // add intermediate point
+  } else if (event.middleDown()) {
+    return processMouseMiddleButtonPressed(); // remove last intermediate point
+  }
+
+  return 0;
+}
+
+int PlanRouteTool::processMouseLeftButtonPressed(std::pair<bool, Ogre::Vector3> xy_plane_intersection) {
+  int flags = 0;
+
+  if (xy_plane_intersection.first) {
+    double position_x = xy_plane_intersection.second.x;
+    double position_y = xy_plane_intersection.second.y;
+    destination_.header.stamp = clock_->now();
+    destination_.header.frame_id = context_->getFixedFrame().toStdString();
+    destination_.point.x = position_x;
+    destination_.point.y = position_y;
+    // onPoseSet(position_x, position_y, 0.0);
+
+    planRoute();
+
+    flags |= (Finished | Render);
+  }
+
+  return flags;
+}
+
+int PlanRouteTool::processMouseRightButtonPressed(std::pair<bool, Ogre::Vector3> xy_plane_intersection) {
+  int flags = 0;
+
+  if (xy_plane_intersection.first) {
+    double position_x = xy_plane_intersection.second.x;
+    double position_y = xy_plane_intersection.second.y;
+    geometry_msgs::msg::PointStamped point;
+    point.header.stamp = clock_->now();
+    point.header.frame_id = context_->getFixedFrame().toStdString();
+    point.point.x = position_x;
+    point.point.y = position_y;
+
+    intermediates_.push_back(point);
+
+    flags |= Render;
+  }
+
+  return flags;
+}
+
+int PlanRouteTool::processMouseMiddleButtonPressed() {
+  int flags = 0;
+
+  if (intermediates_.size() > 0) {
+    intermediates_.pop_back();
+    drawIntermediates(intermediates_);
+    flags |= Render;
+  }
+
+  return flags;
+}
+
+void PlanRouteTool::drawIntermediates(std::vector<geometry_msgs::msg::PointStamped> points) {
+  intermediate_shapes_.clear();
+
+  for (const auto& point : points) {
+    std::shared_ptr<rviz_rendering::Shape> sphere = std::make_shared<rviz_rendering::Shape>(rviz_rendering::Shape::Sphere, scene_manager_, nullptr);
+    Ogre::Vector3 pos(point.point.x, point.point.y, point.point.z);
+    sphere->setPosition(pos);
+    sphere->setColor(0.0f, 1.0f, 0.0f, 1.0f); // Set sphere color to green
+    sphere->setScale(Ogre::Vector3(1.0, 1.0, 1.0));
+    intermediate_shapes_.push_back(sphere);
+  }
+}
+
+void PlanRouteTool::planRoute() {
+  if (!action_client_->wait_for_action_server(std::chrono::seconds(1))) {
+    RCLCPP_ERROR(rclcpp::get_logger("PlanRouteTool"), "Action server not available, cannot plan route.");
+    return;
+  }
+
+  route_planning_msgs::action::PlanRoute::Goal goal;
+  goal.destination = destination_;
+  goal.intermediates = intermediates_;
+
+  auto send_goal_options = rclcpp_action::Client<route_planning_msgs::action::PlanRoute>::SendGoalOptions();
+  send_goal_options.goal_response_callback =
+      [this](rclcpp_action::ClientGoalHandle<route_planning_msgs::action::PlanRoute>::SharedPtr goal_handle) {
+        if (!goal_handle) {
+          RCLCPP_ERROR(rclcpp::get_logger("PlanRouteTool"), "Goal was rejected by the action server.");
+        } else {
+          RCLCPP_INFO(rclcpp::get_logger("PlanRouteTool"), "Goal accepted by the action server, waiting for result.");
+        }
+      };
+
+  send_goal_options.result_callback =
+      [this](const rclcpp_action::ClientGoalHandle<route_planning_msgs::action::PlanRoute>::WrappedResult& result) {
+        if (result.code == rclcpp_action::ResultCode::SUCCEEDED) {
+          if (result.result->destination_reached) {
+            RCLCPP_INFO(this->get_logger(), "Goal succeeded: destination reached after %.2fm and %ds", result.result->distance_traveled,
+                        result.result->time_traveled.sec);
+          } else {
+            RCLCPP_WARN(this->get_logger(), "Goal succeeded, but destination not reached after %.2fm and %ds",
+                        result.result->distance_traveled, result.result->time_traveled.sec);
+          }
+        } else if (result.code == rclcpp_action::ResultCode::CANCELED) {
+          RCLCPP_WARN(this->get_logger(), "Goal canceled: traveled %.2fm and %ds", result.result->distance_traveled, result.result->time_traveled.sec);
+        } else if (result.code == rclcpp_action::ResultCode::ABORTED) {
+          RCLCPP_ERROR(this->get_logger(), "Goal aborted: traveled %.2fm and %ds", result.result->distance_traveled, result.result->time_traveled.sec);
+        } else {
+          RCLCPP_ERROR(this->get_logger(), "Goal finished with unknown result code: %d", static_cast<int>(result.code));
+        }
+      };
+
+  action_client_->async_send_goal(goal, send_goal_options);
+}
+
+
+}  // namespace tools
+}  // namespace route_planning_msgs
+
+#include <pluginlib/class_list_macros.hpp>  // NOLINT
+PLUGINLIB_EXPORT_CLASS(route_planning_msgs::tools::PlanRouteTool, rviz_common::Tool)

--- a/route_planning_msgs_rviz_plugins/src/tools/route/ref_path_tool.cpp
+++ b/route_planning_msgs_rviz_plugins/src/tools/route/ref_path_tool.cpp
@@ -293,9 +293,9 @@ int ReferencePathTool::processMouseEvent(rviz_common::ViewportMouseEvent& event)
       projection_finder_->getViewportPointProjectionOnXYPlane(event.panel->getRenderWindow(), event.x, event.y);
 
   if (event.leftDown()) {
-    return processMouseLeftButtonPressed(point_projection_on_xy_plane);
+    return processMouseLeftButtonPressed();
   } else if (event.rightDown()) {
-    return processMouseRightButtonPressed();
+    return processMouseRightButtonPressed(point_projection_on_xy_plane);
   } else if (event.middleDown()) {
     return processMouseMiddleButtonPressed();
   }
@@ -303,7 +303,7 @@ int ReferencePathTool::processMouseEvent(rviz_common::ViewportMouseEvent& event)
   return 0;
 }
 
-int ReferencePathTool::processMouseLeftButtonPressed(std::pair<bool, Ogre::Vector3> xy_plane_intersection) {
+int ReferencePathTool::processMouseRightButtonPressed(std::pair<bool, Ogre::Vector3> xy_plane_intersection) {
   int flags = 0;
   if (init_point_property_->getBool() && ref_path_points_.empty()) {
     if (setInitPoint()) {
@@ -327,7 +327,7 @@ int ReferencePathTool::processMouseLeftButtonPressed(std::pair<bool, Ogre::Vecto
   return flags;
 }
 
-int ReferencePathTool::processMouseRightButtonPressed() {
+int ReferencePathTool::processMouseMiddleButtonPressed() {
   int flags = 0;
   if ((init_point_property_->getBool() && ref_path_points_.size() > 1) ||
       (!init_point_property_->getBool() && !ref_path_points_.empty())) {
@@ -341,7 +341,7 @@ int ReferencePathTool::processMouseRightButtonPressed() {
   return flags;
 }
 
-int ReferencePathTool::processMouseMiddleButtonPressed() {
+int ReferencePathTool::processMouseLeftButtonPressed() {
   int flags = 0;
   std::vector<geometry_msgs::msg::PointStamped> route_points;
 

--- a/tf2_route_planning_msgs/include/tf2_route_planning_msgs/tf2_route_planning_msgs.hpp
+++ b/tf2_route_planning_msgs/include/tf2_route_planning_msgs/tf2_route_planning_msgs.hpp
@@ -105,6 +105,11 @@ inline void doTransform(const Route& route_in, Route& route_out, const geometry_
   // destination
   doTransform(route_in.destination, route_out.destination, transform);
 
+  // intermediates
+  for (size_t i = 0; i < route_in.intermediates.size(); i++) {
+    doTransform(route_in.intermediates[i], route_out.intermediates[i], transform);
+  }
+
   // route elements
   for (size_t i = 0; i < route_in.route_elements.size(); i++) {
     doTransform(route_in.route_elements[i], route_out.route_elements[i], transform);

--- a/tf2_route_planning_msgs/include/tf2_route_planning_msgs/tf2_route_planning_msgs.hpp
+++ b/tf2_route_planning_msgs/include/tf2_route_planning_msgs/tf2_route_planning_msgs.hpp
@@ -105,9 +105,9 @@ inline void doTransform(const Route& route_in, Route& route_out, const geometry_
   // destination
   doTransform(route_in.destination, route_out.destination, transform);
 
-  // intermediates
-  for (size_t i = 0; i < route_in.intermediates.size(); i++) {
-    doTransform(route_in.intermediates[i], route_out.intermediates[i], transform);
+  // intermediate destinations
+  for (size_t i = 0; i < route_in.intermediate_destinations.size(); i++) {
+    doTransform(route_in.intermediate_destinations[i], route_out.intermediate_destinations[i], transform);
   }
 
   // route elements

--- a/tf2_route_planning_msgs/src/tf2_route_planning_msgs/tf2_route_planning_msgs.py
+++ b/tf2_route_planning_msgs/src/tf2_route_planning_msgs/tf2_route_planning_msgs.py
@@ -134,6 +134,12 @@ def do_transform_route(msg: Route, transform: TransformStamped) -> Route:
     point.point = msg.destination
     msg_out.destination = tf2_geometry_msgs.do_transform_point(point, transform).point
 
+    # intermediates
+    for i in range(len(msg.intermediates)):
+        point = PointStamped()
+        point.point = msg.intermediates[i]
+        msg_out.intermediates[i] = tf2_geometry_msgs.do_transform_point(point, transform).point
+
     # route_elements
     for i in range(len(msg.route_elements)):
         msg_out.route_elements[i] = do_transform_route_element(msg.route_elements[i], transform)

--- a/tf2_route_planning_msgs/src/tf2_route_planning_msgs/tf2_route_planning_msgs.py
+++ b/tf2_route_planning_msgs/src/tf2_route_planning_msgs/tf2_route_planning_msgs.py
@@ -134,11 +134,11 @@ def do_transform_route(msg: Route, transform: TransformStamped) -> Route:
     point.point = msg.destination
     msg_out.destination = tf2_geometry_msgs.do_transform_point(point, transform).point
 
-    # intermediates
-    for i in range(len(msg.intermediates)):
+    # intermediate destinations
+    for i in range(len(msg.intermediate_destinations)):
         point = PointStamped()
-        point.point = msg.intermediates[i]
-        msg_out.intermediates[i] = tf2_geometry_msgs.do_transform_point(point, transform).point
+        point.point = msg.intermediate_destinations[i]
+        msg_out.intermediate_destinations[i] = tf2_geometry_msgs.do_transform_point(point, transform).point
 
     # route_elements
     for i in range(len(msg.route_elements)):

--- a/tf2_route_planning_msgs/test/test_tf2_route_planning_msgs.cpp
+++ b/tf2_route_planning_msgs/test/test_tf2_route_planning_msgs.cpp
@@ -86,6 +86,8 @@ TEST(tf2_route_planning_msgs, test_doTransform_Route) {
   // Define a route 
   Route route, route_tf;
   route.destination = point_in;
+  route.intermediates.push_back(point_in);
+  route.intermediates.push_back(point_in);
   route.route_elements.push_back(route_element);
 
   gm::TransformStamped tf;
@@ -101,6 +103,9 @@ TEST(tf2_route_planning_msgs, test_doTransform_Route) {
 
   // transformed route
   EXPECT_EQ(route_tf.destination, point_out);
+  EXPECT_EQ(route_tf.intermediates.size(), 2);
+  EXPECT_EQ(route_tf.intermediates[0], point_out);
+  EXPECT_EQ(route_tf.intermediates[1], point_out);
   EXPECT_EQ(route_tf.route_elements.size(), 1);
   EXPECT_EQ(route_tf.route_elements[0].lane_elements.size(), 1);
   EXPECT_EQ(route_tf.route_elements[0].left_boundary, point_out);

--- a/tf2_route_planning_msgs/test/test_tf2_route_planning_msgs.cpp
+++ b/tf2_route_planning_msgs/test/test_tf2_route_planning_msgs.cpp
@@ -86,8 +86,8 @@ TEST(tf2_route_planning_msgs, test_doTransform_Route) {
   // Define a route 
   Route route, route_tf;
   route.destination = point_in;
-  route.intermediates.push_back(point_in);
-  route.intermediates.push_back(point_in);
+  route.intermediate_destinations.push_back(point_in);
+  route.intermediate_destinations.push_back(point_in);
   route.route_elements.push_back(route_element);
 
   gm::TransformStamped tf;
@@ -103,9 +103,9 @@ TEST(tf2_route_planning_msgs, test_doTransform_Route) {
 
   // transformed route
   EXPECT_EQ(route_tf.destination, point_out);
-  EXPECT_EQ(route_tf.intermediates.size(), 2);
-  EXPECT_EQ(route_tf.intermediates[0], point_out);
-  EXPECT_EQ(route_tf.intermediates[1], point_out);
+  EXPECT_EQ(route_tf.intermediate_destinations.size(), 2);
+  EXPECT_EQ(route_tf.intermediate_destinations[0], point_out);
+  EXPECT_EQ(route_tf.intermediate_destinations[1], point_out);
   EXPECT_EQ(route_tf.route_elements.size(), 1);
   EXPECT_EQ(route_tf.route_elements[0].lane_elements.size(), 1);
   EXPECT_EQ(route_tf.route_elements[0].left_boundary, point_out);

--- a/tf2_route_planning_msgs/test/test_tf2_route_planning_msgs.py
+++ b/tf2_route_planning_msgs/test/test_tf2_route_planning_msgs.py
@@ -74,8 +74,8 @@ def test_do_transform_route():
     # Define a Route
     route = Route()
     route.destination = deepcopy(point_in)
-    route.intermediates.append(deepcopy(point_in))
-    route.intermediates.append(deepcopy(point_in))
+    route.intermediate_destinations.append(deepcopy(point_in))
+    route.intermediate_destinations.append(deepcopy(point_in))
     route.route_elements.append(deepcopy(route_element))
 
     # Create a TransformStamped object
@@ -93,9 +93,9 @@ def test_do_transform_route():
 
     # Assert the transformed route
     assert route_tf.destination == point_out
-    assert len(route_tf.intermediates) == 2
-    assert route_tf.intermediates[0] == point_out
-    assert route_tf.intermediates[1] == point_out
+    assert len(route_tf.intermediate_destinations) == 2
+    assert route_tf.intermediate_destinations[0] == point_out
+    assert route_tf.intermediate_destinations[1] == point_out
     assert len(route_tf.route_elements) == 1
     assert len(route_tf.route_elements[0].lane_elements) == 1
     assert route_tf.route_elements[0].left_boundary == point_out

--- a/tf2_route_planning_msgs/test/test_tf2_route_planning_msgs.py
+++ b/tf2_route_planning_msgs/test/test_tf2_route_planning_msgs.py
@@ -74,6 +74,8 @@ def test_do_transform_route():
     # Define a Route
     route = Route()
     route.destination = deepcopy(point_in)
+    route.intermediates.append(deepcopy(point_in))
+    route.intermediates.append(deepcopy(point_in))
     route.route_elements.append(deepcopy(route_element))
 
     # Create a TransformStamped object
@@ -91,6 +93,9 @@ def test_do_transform_route():
 
     # Assert the transformed route
     assert route_tf.destination == point_out
+    assert len(route_tf.intermediates) == 2
+    assert route_tf.intermediates[0] == point_out
+    assert route_tf.intermediates[1] == point_out
     assert len(route_tf.route_elements) == 1
     assert len(route_tf.route_elements[0].lane_elements) == 1
     assert route_tf.route_elements[0].left_boundary == point_out

--- a/trajectory_planning_msgs_rviz_plugins/CMakeLists.txt
+++ b/trajectory_planning_msgs_rviz_plugins/CMakeLists.txt
@@ -13,9 +13,6 @@ if(${ROS_VERSION} EQUAL 2)
 
   # find dependencies
   find_package(ament_cmake REQUIRED)
-  # uncomment the following section in order to fill in
-  # further dependencies manually.
-  # find_package(<dependency> REQUIRED)
   find_package(geometry_msgs REQUIRED)
   find_package(pluginlib REQUIRED)
   find_package(rclcpp REQUIRED)
@@ -94,6 +91,11 @@ if(${ROS_VERSION} EQUAL 2)
     ARCHIVE DESTINATION lib
     LIBRARY DESTINATION lib
     RUNTIME DESTINATION bin
+  )
+
+  install(
+    DIRECTORY icons/classes/
+    DESTINATION share/${PROJECT_NAME}/icons/classes
   )
   # RViz Display End
 

--- a/trajectory_planning_msgs_rviz_plugins/icons/classes/Trajectory.png
+++ b/trajectory_planning_msgs_rviz_plugins/icons/classes/Trajectory.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:243c5cc80cd5707e6cc07b0889c9c8d4f1a20a0a697f65333e6115536af704be
+size 856


### PR DESCRIPTION
- add new request field `intermediates` to `PlanRoute.action` to enable planning a route via predefined intermediate goals (could be empty -> previous behavior)
- add this field also to the `Route.msg` and implement corresponding tf and visualization functions
- add new RViz tool for planning such a route
  - right click -> add intermediate goal
  - middle click -> delete last intermediate goal
  - left klick -> adds a destination and calls the action server
- adds icons to RViz plugins ([rviz-icons.pptx](https://github.com/user-attachments/files/21613292/rviz-icons.pptx))
